### PR TITLE
ci: use CFLite to test forks (including systemd-stable)

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:14b332de0e18683f37386eaedbf735bc6e8d81f9c0e1138d620f2178e20cd30a
+COPY . $SRC/systemd
+WORKDIR $SRC/systemd
+COPY tools/oss-fuzz.sh $SRC/build.sh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,31 @@
+---
+# vi: ts=2 sw=2 et:
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+name: ClusterFuzzLite continuous builds
+on:
+  push:
+    branches:
+      - main
+      - v[0-9]+-stable
+
+permissions: read-all
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    if: github.repository != 'systemd/systemd'
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@41dccd0566905e2a7d1724e7883edbfa66d78877
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        upload-build: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,39 @@
+---
+# vi: ts=2 sw=2 et:
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    branches:
+      - main
+      - v[0-9]+-stable
+
+permissions: read-all
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    if: github.repository != 'systemd/systemd' || github.event.pull_request.user.login == 'dependabot[bot]'
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@41dccd0566905e2a7d1724e7883edbfa66d78877
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@41dccd0566905e2a7d1724e7883edbfa66d78877
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 1200
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/tools/oss-fuzz.sh
+++ b/tools/oss-fuzz.sh
@@ -80,7 +80,7 @@ rm -rf "$hosts"
 
 # The seed corpus is a separate flat archive for each fuzzer,
 # with a fixed name ${fuzzer}_seed_corpus.zip.
-for d in "$(dirname "$0")/../test/fuzz/fuzz-"*; do
+for d in test/fuzz/fuzz-*; do
     zip -jqr "$OUT/$(basename "$d")_seed_corpus.zip" "$d"
 done
 


### PR DESCRIPTION
It's like CIFuzz but unlike CIFuzz it's compatible with forks and
it should make it possible to run the fuzzers to make sure that
patches backported to them are backported correctly without introducing
new bugs and regressions.