### PR TITLE
ci: unpin CFLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:14b332de0e18683f37386eaedbf735bc6e8d81f9c0e1138d620f2178e20cd30a
+FROM gcr.io/oss-fuzz-base/base-builder:v1
 ENV MERGE_WITH_OSS_FUZZ_CORPORA=yes
 COPY . $SRC/systemd
 WORKDIR $SRC/systemd

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -25,13 +25,13 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@41dccd0566905e2a7d1724e7883edbfa66d78877
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
         sanitizer: ${{ matrix.sanitizer }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@41dccd0566905e2a7d1724e7883edbfa66d78877
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 1200


### PR DESCRIPTION
The idea was to catch CFLite regressions but since the action itself
pulls the latest docker images it can't be pinned properly and issues
like https://github.com/google/clusterfuzzlite/issues/91 are going to
pop up anyway. Let's unpin it by analogy with CIFuzz and hope it doesn't
break very often.

Waiting for https://github.com/google/clusterfuzzlite/pull/96